### PR TITLE
Add tests to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Only allow one instance of this workflow for each PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
+      with:
+        python-version: |
+          3.12
+          3.13
+        cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          tox.ini
+    - run: pip install --group test_runners
+
+    - run: tox run-parallel --parallel-no-spinner
+      env:
+        FORCE_COLOR: "1"
+        DEFAULT_DATABASE_URL: postgres://postgres:postgres@localhost/subatomic
+        OTHER_DATABASE_URL: postgres://postgres:postgres@localhost/subatomic_other
+
+    - run: pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ mypy = [
 test_runners = [
     # Test matrix management
     "tox",
+    "tox-uv",
 
     # Pre-commit checks
     "pre-commit",


### PR DESCRIPTION
This is adapted from `timezone-tools` and `django-sans-db`:

- https://github.com/kraken-tech/timezone-tools/blob/1cadfdb1a3726a2d78f6c06234ce4037bbd22048/.github/workflows/tests.yaml
- https://github.com/meshy/django-sans-db/blob/debfadce9452656b78e634319d8579f8cb9c0a16/.github/workflows/tests.yml

This should have been merged in #2, but that PR had the wrong target branch.