### PR TITLE
Skip pre-commit check that only applies locally

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,3 +48,5 @@ jobs:
         OTHER_DATABASE_URL: postgres://postgres:postgres@localhost/subatomic_other
 
     - run: pre-commit run --all-files
+      env:
+        SKIP: no-commit-to-branch


### PR DESCRIPTION
This rule which prevents committing to the main branch was causing CI to fail when running on the main branch.