### PR TITLE
Measure code coverage when running tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ docs = [
     "mkdocs-api-autonav",
     "mkdocs-material>=9.5.0",
 ]
+coverage = [
+    "coverage",
+]
 mypy = [
     {include-group = "python_tests"},
     "django-stubs[compatible-mypy]",
@@ -102,3 +105,25 @@ exclude = "build/"
 strict = true
 warn_unreachable = true
 warn_no_return = true
+
+
+# Coverage
+[tool.coverage.run]
+branch = true
+core = "sysmon"
+source_pkgs = [
+    "django_subatomic",
+    "tests",
+]
+
+[tool.coverage.paths]
+source = [
+    "src",
+    ".tox/*/lib/*/site-packages/",
+]
+
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+skip_covered = true
+skip_empty = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,6 +36,7 @@ ignore = [
     "PLR5501", # Use `elif` instead of `else` then `if`, to reduce indentation
     "PLR6301", # Method `foo` could be a function or static method
     "PT007",  # Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
+    "PT012", # `pytest.raises()` block should contain a single simple statement.
     "PYI041", # Use `float` instead of `int | float`
     "RET505", # Unnecessary `else` after `return` statement
     "RUF001", # String contains ambiguous `’` (RIGHT SINGLE QUOTATION MARK). Did you mean ``` (GRAVE ACCENT)?

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,5 +21,8 @@ def django_db_modify_db_settings_tox_suffix() -> None:
     fixtures.skip_if_no_django()  # type: ignore[attr-defined]
 
     tox_environment = os.getenv("TOX_ENV_NAME")
-    if tox_environment:
+
+    # We only measure coverage when running tests with tox,
+    # so coverage never sees the path where "if tox_environment" is false.
+    if tox_environment:  # pragma: no branch
         fixtures._set_suffix_to_test_databases(suffix=tox_environment)  # noqa: SLF001

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -13,3 +13,6 @@ DATABASES = {
     ),
 }
 USE_TZ = True
+
+# It's OK for us to hard-code this secret key for the tests.
+SECRET_KEY = "hunter2"  # noqa: S105

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -85,7 +85,7 @@ class TestTransaction:
                 ),
             ):
                 with db.transaction():
-                    pass
+                    ...  # An exception is raised before we enter the body of this block.
 
     @pytest.mark.django_db(transaction=True)
     def test_creates_transaction(self) -> None:
@@ -155,7 +155,7 @@ class TestTransactionRequired:
         """
         with pytest.raises(db._MissingRequiredTransaction) as exc:  # noqa: SLF001
             with db.transaction_required():
-                pass
+                ...  # An exception is raised before we enter the body of this block.
 
         assert exc.value.database == DEFAULT
 
@@ -178,12 +178,13 @@ class TestTransactionRequired:
         """
         No error is raised when we're in a transaction.
         """
+        code_is_reached = False
+
         with db.transaction():
-            try:
-                with db.transaction_required():
-                    ...
-            except db._MissingRequiredTransaction:  # noqa: SLF001
-                pytest.fail("We should not have raised MissingRequiredTransaction.")
+            with db.transaction_required():
+                code_is_reached = True
+
+        assert code_is_reached is True
 
 
 class TestSavepointContextManager:
@@ -194,7 +195,7 @@ class TestSavepointContextManager:
         # Note: We didn't create a transaction first.
         with pytest.raises(db._MissingRequiredTransaction) as exc:  # noqa: SLF001
             with db.savepoint():
-                pass
+                ...  # An exception is raised before we enter the body of this block.
 
         assert exc.value.database == DEFAULT
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ requires =
 
 env_list =
     py3{12,13,14}-django{42,51,52}
+    coverage
     mypy
 
 [testenv]
@@ -18,6 +19,7 @@ pass_env =
     OTHER_DATABASE_URL
 
 dependency_groups =
+    coverage
     python_tests
 
 deps =
@@ -26,8 +28,18 @@ deps =
     django52: django~=5.2.0
 
 commands =
-    python -m pytest {posargs}
+    coverage run --parallel -m pytest {posargs}
 
+[testenv:coverage]
+depends =
+    py3{12,13,14}-django{42,51,52}
+
+dependency_groups =
+    coverage
+
+commands =
+    coverage combine
+    coverage report
 
 [testenv:mypy]
 dependency_groups =


### PR DESCRIPTION
This adds Coverage to check how much of our code is covered when running tests, and ensures we have complete test coverage.

Fixes #6.