### PR TITLE
Control after-commit behaviour with a setting

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -48,8 +48,6 @@ addopts =
 markers =
     # See Note [Running after-commit callbacks in tests]
     deprecated_ignore_after_commit_callbacks: require after-commit callbacks to be explicitly captured and called
-    # See Note [After-commit callbacks require a transaction]
-    deprecated_run_after_commit_outside_transaction: relax rule where after-commit callbacks require a transaction
 
 # Ensure passing xfailed (aka "xpass") tests cause the test suite to fail.
 # https://docs.pytest.org/en/latest/skipping.html#strict-parameter


### PR DESCRIPTION
By default, `run_after_commit` will raise an error if it is called when it's not in a transaction. This could previously be controlled using a test marker which monkey-patched a value in another module.

This new setting, `SUBATOMIC_AFTER_COMMIT_NEEDS_TRANSACTION`, allows projects to disable this strict behaviour without resorting to monkey-patching.

Fixes #20 