### PR TITLE
Control after-commit calls in tests with a setting

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -45,10 +45,6 @@ addopts =
 #   https://pytest-django.readthedocs.io/
     -p django
 
-markers =
-    # See Note [Running after-commit callbacks in tests]
-    deprecated_ignore_after_commit_callbacks: require after-commit callbacks to be explicitly captured and called
-
 # Ensure passing xfailed (aka "xpass") tests cause the test suite to fail.
 # https://docs.pytest.org/en/latest/skipping.html#strict-parameter
 xfail_strict = true


### PR DESCRIPTION
By default, in (non transaction testcase) tests, we simulate the execution of after-commit callbacks, to reproduce Django's normal behaviour when outside of tests.

To allow projects to migrate their existing code over to this new paradigm gradually, we allow this behaviour to be disabled. This was previously controlled by monkey-patching a module scoped value in tests, but is now exposed with a Django setting: `SUBATOMIC_RUN_AFTER_COMMIT_CALLBACKS_IN_TESTS`.

Fixes #9.