### PR TITLE
Test against Python3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
         python-version: |
           3.12
           3.13
+          3.14
+        allow-prereleases: true
         cache: 'pip'
         cache-dependency-path: |
           pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Verified compatibility with Python3.14.
+
 ## [0.1.0] - 2025-09-17
 
 The first release of django-subatomic.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Splits Django's `atomic` into a suite of more specific utilities.
 
 This package supports sensible combinations of:
 
-- Python 3.12, 3.13.
+- Python 3.12, 3.13, 3.14.
 - Django 4.2, 5.1, 5.2.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Typing :: Typed",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4
 
 env_list =
-    py3{12,13}-django{42,51,52}
+    py3{12,13,14}-django{42,51,52}
     mypy
 
 [testenv]


### PR DESCRIPTION
This has release candidates and is available for testing. We should
ensure we support this version of Python before it becomes a supported
version.

Resolves #22 