### PR TITLE
Prepare pre-commit for running with pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,5 @@ repos:
 
       - id: ruff-format # Run `ruff` formatter
         name: Check 'ruff format' passes
+ci:
+  autofix_prs: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files # Prevent giant files from being committed
       - id: check-case-conflict # Checks for files that conflict in case-insensitive filesystems


### PR DESCRIPTION
This prepares the repository for integration with [pre-commit CI](https://pre-commit.ci). Once this has merged, we will enable the integration, then remove pre-commit from our GitHub Actions workflow.