### PR TITLE
Remove `pre-commit` from test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,3 @@ jobs:
         FORCE_COLOR: "1"
         DEFAULT_DATABASE_URL: postgres://postgres:postgres@localhost/subatomic
         OTHER_DATABASE_URL: postgres://postgres:postgres@localhost/subatomic_other
-
-    - run: pre-commit run --all-files
-      env:
-        SKIP: no-commit-to-branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     {include-group = "mypy"},
     {include-group = "test_runners"},
     {include-group = "python_tests"},
+    "pre-commit",
 ]
 mypy = [
     {include-group = "python_tests"},
@@ -75,9 +76,6 @@ test_runners = [
     # Test matrix management
     "tox",
     "tox-uv",
-
-    # Pre-commit checks
-    "pre-commit",
 ]
 python_tests = [
     # Python test suite


### PR DESCRIPTION
We now run pre-commit through the pre-commit CI service, so do not need
to duplicate it here.

This has the benefit of reducing then umber of packages we need to
install in the test runners, which speeds up installation.

Resolves #19