### PR TITLE
Add search plugin to MkDocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Seach plugin for MkDocs
+
 ## [0.1.1] - 2025-09-20
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,4 +10,5 @@ extra:
     default:
       - latest
 plugins:
+  - search
   - mike


### PR DESCRIPTION
## Overview

- This adds the search plugin to Mkdocs

## Other changes

- Several options could be added as extra [configs ](https://www.mkdocs.org/user-guide/configuration/#search)to the plugin, if needed, such as:

-  `separator`, currently `whitespace` and `hyphen` are used.
- `min_search_length`, minimum length for a search query, defaults to 3
