### PR TITLE
Use up-to-date OxiPNG github url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: ruff-format # Run `ruff` formatter
         name: Check 'ruff format' passes
 
-  - repo: https://github.com/shssoichiro/oxipng
+  - repo: https://github.com/oxipng/oxipng
     rev: v9.1.5
     hooks:
       - id: oxipng


### PR DESCRIPTION
`https://github.com/shssoichiro/oxipng` redirects to `https://github.com/oxipng/oxipng`.