### PR TITLE
Tidy up generated API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Search plugin for MkDocs
 
+### Removed
+
+- `django_subatomic.db.NotADecorator` is no longer a part of the public API.
+  It has been renamed to `_NotADecorator`.
+  This implementation detail was not intended for general use,
+  and may be removed in a future release.
+
 ## [0.1.1] - 2025-09-20
 
 ### Added

--- a/docs/why.md
+++ b/docs/why.md
@@ -23,10 +23,12 @@ Django's atomic creates many savepoints that are never used. There are a couple 
 
 1. Savepoints are created with decorators (`@atomic`).
 2. `atomic` creates savepoints by default. The default arguments (*Behaviour* **A**) are an [attractive nuisance](https://blog.ganssle.io/articles/2023/01/attractive-nuisances.html) because they make us create savepoints when we don't need them.
+
     > … if you have two ways to accomplish a task and one is a simple way that *looks* like the right thing but is subtly wrong, and the other is correct but
     > more complicated, the majority of people will end up doing the wrong
     > thing.
     > — [**Attractive nuisances in software design**](https://blog.ganssle.io/articles/2023/01/attractive-nuisances.html) - [Paul Ganssle](https://blog.ganssle.io/author/paul-ganssle.html)
+
 3. We have no easy way to indicate the creation of a savepoint that doesn't have the potential to create a transaction instead. The only tool we have to create a savepoint is *Behaviour* **A**, which can create a transaction.
 
 ## What Subatomic implements

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,11 @@ extra:
 markdown_extensions:
   - tables
 plugins:
-  - mkdocstrings
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            members_order: source
   - api-autonav:
       modules: ['src/django_subatomic']
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,9 @@ plugins:
         python:
           options:
             members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            show_signature_type_parameters: true
   - api-autonav:
       modules: ['src/django_subatomic']
   - search

--- a/src/django_subatomic/db.py
+++ b/src/django_subatomic/db.py
@@ -140,7 +140,7 @@ def transaction_if_not_already(*, using: str | None = None) -> Iterator[None]:
         yield
 
 
-class NotADecorator(Exception):
+class _NotADecorator(Exception):
     """
     Raised when a context manager is mistakenly used as a decorator.
     """
@@ -157,7 +157,7 @@ class _NonDecoratorContextManager[T_Co](contextlib._GeneratorContextManager[T_Co
     """
 
     def __call__(self, func: object) -> NoReturn:
-        raise NotADecorator
+        raise _NotADecorator
 
 
 def _contextmanager_without_decorator[**P, T_Co](

--- a/src/django_subatomic/db.py
+++ b/src/django_subatomic/db.py
@@ -185,6 +185,7 @@ def savepoint(*, using: str | None = None) -> Generator[None, None, None]:
     Must be called inside an active transaction.
 
     Tips:
+
     - You should only create a savepoint if you may roll back to it before
       continuing with your transaction. If your intention is to ensure that
       your code is committed atomically, consider using `transaction_required`

--- a/src/django_subatomic/db.py
+++ b/src/django_subatomic/db.py
@@ -98,7 +98,7 @@ def transaction(*, using: str | None = None) -> Iterator[None]:
     Create a database transaction.
 
     Nested calls are not allowed because SQL does not support nested transactions.
-    Consider this like `atomic(durable=True)`, but with added after-commit callback support in tests.
+    Consider this like Django's `atomic(durable=True)`, but with added after-commit callback support in tests.
 
     This wraps Django's 'atomic' function.
 
@@ -190,7 +190,7 @@ def savepoint(*, using: str | None = None) -> Generator[None, None, None]:
       continuing with your transaction. If your intention is to ensure that
       your code is committed atomically, consider using `transaction_required`
       instead.
-    - Savepoint rollback should be handled _where we create the savepoint_.
+    - We believe savepoint rollback should be handled where the savepoint is created.
       That locality is not possible with a decorator, so this function
       deliberately does not work as one.
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -202,7 +202,7 @@ class TestSavepointContextManager:
         """
         `savepoint` cannot be used as a decorator.
         """
-        with pytest.raises(db.NotADecorator):
+        with pytest.raises(db._NotADecorator):  # noqa: SLF001
 
             @db.savepoint()
             def inner() -> None: ...


### PR DESCRIPTION
In order to tidy up the API docs, this:

- Fixes some formatting issues
- Removes `NotADecorator` from the public API. (This exception is an implementation detail that should not have been exposed.)
- Re-orders the functions in `django_subatomic.db` to have a more "natural" order in the code and the API docs.
- Adds types to the function signatures in the API docs.

<img width="2769" height="1144" alt="image" src="https://github.com/user-attachments/assets/c26a3f06-9e58-4235-85d9-ecfc7450a047" />
