### PR TITLE
Enable syntax highlighting on code blocks in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ extra:
       - latest
 markdown_extensions:
   - admonition
+  - pymdownx.highlight
+  - pymdownx.superfences
   - tables
   - toc:
       permalink: true


### PR DESCRIPTION
We don't have any code blocks yet, but we'll get them in #57.

Example:

| Before | After |
| --- | --- |
| <img width="519" height="208" alt="Screenshot from 2025-10-06 11-45-26" src="https://github.com/user-attachments/assets/335d2725-8ca2-4e58-be4e-e9291837c902" /> | <img width="519" height="208" alt="Screenshot from 2025-10-06 11-49-12" src="https://github.com/user-attachments/assets/b6bd465b-8066-4f77-b365-4c162a9c709d" /> |

Fixes #55 

Docs: https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#highlight

