### PR TITLE
Use shorter name for docs link to GitHub

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Django-subatomic docs
-repo_name: kraken-tech/django-subatomic
+repo_name: Django Subatomic on GitHub
 repo_url: https://github.com/kraken-tech/django-subatomic
 watch:
   - src


### PR DESCRIPTION
The old name was truncated. This new name isn't.

Before:

<img width="475" height="125" alt="image" src="https://github.com/user-attachments/assets/870ba4ac-439f-4a98-b423-035d9cf1b405" />

After:

<img width="475" height="125" alt="image" src="https://github.com/user-attachments/assets/56998da7-2fb2-4e35-b5a7-aa02b2e3a681" />
