### PR TITLE
feat(db): raise when entering transaction if testcase has pending on_…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Search plugin for MkDocs
+- Raise an error when entering `db.transaction()` (and `transaction_if_not_already()` when it opens) **if** the testcase transaction already has pending `on_commit` callbacks.  
+  Opt-out via `SUBATOMIC_RAISE_IF_PENDING_TESTCASE_ON_COMMIT_ON_ENTER` (default: `True`). (#31)
 
 ### Fixed
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -32,3 +32,13 @@ on a per-test basis.
 
 [override_settings]: https://docs.djangoproject.com/en/stable/topics/testing/tools/#django.test.override_settings
 [django-settings]: https://docs.djangoproject.com/en/stable/topics/settings/
+
+
+## `SUBATOMIC_RAISE_IF_PENDING_TESTCASE_ON_COMMIT_ON_ENTER`
+
+**Default:** `True`
+
+When `True`, entering `db.transaction()` (and `transaction_if_not_already()` when it opens) **raises** if the test suite’s transaction already has pending `on_commit` callbacks.  
+This avoids accidentally flushing callbacks that were queued **before** opening an application transaction in tests.
+
+Set to `False` to keep the previous behaviour during migration.

--- a/tests/test_on_commit_guard.py
+++ b/tests/test_on_commit_guard.py
@@ -1,0 +1,39 @@
+# tests/test_on_commit_guard.py
+
+from django.test import TestCase, override_settings
+from django.db import transaction as dj_tx
+
+from django_subatomic import db
+from django_subatomic.db import _PendingTestcaseAfterCommitCallbacks
+
+
+class TestOnCommitGuardWithTransaction(TestCase):
+    def test_raises_on_enter_if_testcase_has_pending_callbacks(self):
+        dj_tx.on_commit(lambda: None)
+        with self.assertRaises(_PendingTestcaseAfterCommitCallbacks):
+            with db.transaction():
+                pass
+
+    @override_settings(SUBATOMIC_RAISE_IF_PENDING_TESTCASE_ON_COMMIT_ON_ENTER=False)
+    def test_opt_out_keeps_previous_behaviour(self):
+        calls = []
+        dj_tx.on_commit(lambda: calls.append("ok"))
+        with db.transaction():
+            self.assertEqual(calls, [])
+        self.assertEqual(calls, ["ok"])
+
+
+class TestOnCommitGuardWithTransactionIfNotAlready(TestCase):
+    def test_raises_on_enter_in_transaction_if_not_already(self):
+        dj_tx.on_commit(lambda: None)
+        with self.assertRaises(_PendingTestcaseAfterCommitCallbacks):
+            with db.transaction_if_not_already():
+                pass
+
+    @override_settings(SUBATOMIC_RAISE_IF_PENDING_TESTCASE_ON_COMMIT_ON_ENTER=False)
+    def test_opt_out_keeps_previous_behaviour_in_transaction_if_not_already(self):
+        calls = []
+        dj_tx.on_commit(lambda: calls.append("ok"))
+        with db.transaction_if_not_already():
+            self.assertEqual(calls, [])
+        self.assertEqual(calls, ["ok"])


### PR DESCRIPTION
Add a guard that raises when entering `db.transaction()`/`transaction_if_not_already()` if the testcase transaction already has pending `on_commit` callbacks (opt-out via setting); closes #31.
