### PR TITLE
Remove docs-related change from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
-
-- Search plugin for MkDocs
-
 ### Fixed
 
 - Ensure cleanup actions in `durable` always happen when the wrapped code raises an unexpected error.


### PR DESCRIPTION
This change is not packaged and will affect the whole docs site, not
just for the next released version of the Python package. As such, it is
out of place in this changelog.

This is a nitpick, I'm aware.