### PR TITLE
Allow mypy to show color output in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,3 +47,6 @@ dependency_groups =
 
 commands =
     python -m mypy .
+
+set_env =
+    TERM=xterm-256color


### PR DESCRIPTION
Before this change, the `TERM` environment variable was set to `dumb`,
which mypy interprets as being unable to display color. This means
that even the `FORCE_COLOR` environment variable does not force mypy to
output color.

This change sets the `TERM` environment variable to allow mypy to output
colors, making the mypy output easier to identify and interpret in CI.

See python/mypy#13817 for more information about this problem.

---

[Before](https://github.com/kraken-tech/django-subatomic/actions/runs/18353701910/job/52280139010?pr=89):

<img width="844" height="317" alt="Screenshot 2025-10-08 at 19 13 55" src="https://github.com/user-attachments/assets/35e76221-d0d6-45ba-a8b6-de8f1b27e71c" />

[After](https://github.com/kraken-tech/django-subatomic/actions/runs/18354238421/job/52281974996?pr=89):

<img width="838" height="314" alt="Screenshot 2025-10-08 at 19 24 34" src="https://github.com/user-attachments/assets/b0bc7265-eae5-451b-8d59-200e79ce0908" />
