### PR TITLE
Allow mypy to show color output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,7 @@ jobs:
     - run: tox run-parallel --parallel-no-spinner
       env:
         FORCE_COLOR: "1"
+        MYPY_FORCE_COLOR: "yes"
         DEFAULT_DATABASE_URL: postgres://postgres:postgres@localhost/subatomic
         OTHER_DATABASE_URL: postgres://postgres:postgres@localhost/subatomic_other
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,3 +47,6 @@ dependency_groups =
 
 commands =
     python -m mypy .
+
+pass_env =
+    MYPY_FORCE_COLOR


### PR DESCRIPTION
Before this change, the `TERM` environment variable was set to `dumb`,
which mypy interprets as being unable to display color. This means
that even the `FORCE_COLOR` environment variable does not force mypy to
output color.

This change sets the `TERM` environment variable to allow mypy to output
colors, making the mypy output easier to identify and interpret in CI.

See python/mypy#13817 for more information
about this problem.
