### PR TITLE
Raise error when encountering unhandled callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Django 6.0 has been added to the test matrix.
+- In tests, an error will now be raised when opening a transaction if there are pre-existing unhandled after-commit callbacks.
+  The pre-existing callbacks would previously run when `transaction` exits.
+  This helps catch order-of-execution bugs in tests.
+  The error can be silenced by setting the `SUBATOMIC_CATCH_UNHANDLED_AFTER_COMMIT_CALLBACKS_IN_TESTS` setting to `False`
+  to facilitate gradual adoption of this stricter rule.
 
 ### Fixed
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -30,5 +30,25 @@ progressively enable after-commit callbacks in tests
 by using [`override_settings`][override_settings]
 on a per-test basis.
 
+## `SUBATOMIC_CATCH_UNHANDLED_AFTER_COMMIT_CALLBACKS_IN_TESTS`
+
+(default: `True`)
+
+[`transaction`][django_subatomic.db.transaction]
+will raise `_UnhandledCallbacks` in tests
+if it detects any lingering unhandled after-commit callbacks
+when it's called.
+Note: because this exception represents a programming error,
+it starts with an underscore to discourage anyone from catching it.
+
+This highlights order-of-execution issues in tests
+caused by after-commit callbacks having not been run.
+This can only happen in tests without after-commit callback simulation
+(such as those using Django's `atomic` directly),
+because in live systems after commit callbacks are always handled or discarded.
+
+The error can be silenced by setting this to `False`,
+in which case, the lingering callbacks will be run by the transaction after it commits.
+
 [override_settings]: https://docs.djangoproject.com/en/stable/topics/testing/tools/#django.test.override_settings
 [django-settings]: https://docs.djangoproject.com/en/stable/topics/settings/


### PR DESCRIPTION
Before now, exiting `transaction` would run all after-commit callbacks, on the assumption that they were enqueued inside the transaction. In tests this sometimes hid order-of-execution bugs, where pre-existing unhandled after-commit callbacks would get called, but at the wrong time.

When opening a transaction, we will now check for pre-existing unhandled after-commit callbacks, and raise an error when they're found.


Fixes #31 

Alternative to #87