### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-01-21
+
 ### Added
 
 - Django 6.0 has been added to the test matrix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "django-subatomic"
 description = "Fine-grained database transaction control for Django."
-version = "0.1.1"
+version = "0.2.0"
 
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]


### PR DESCRIPTION
The [changelog for this version](https://github.com/kraken-tech/django-subatomic/blob/9a682bda0bfdac68b5849fefdb13d0dde55c2883/CHANGELOG.md) reads:

### Added

- Django 6.0 has been added to the test matrix.
- In tests, an error will now be raised when opening a transaction if there are pre-existing unhandled after-commit callbacks. The pre-existing callbacks would previously run when `transaction` exits. This helps catch order-of-execution bugs in tests. The error can be silenced by setting the  `SUBATOMIC_CATCH_UNHANDLED_AFTER_COMMIT_CALLBACKS_IN_TESTS` setting to `False` to facilitate gradual adoption of this stricter rule.
- The `transaction`, `transaction_required` and `transaction_if_not_already` decorators can now be used without parentheses. Fixes #103.
### Fixed
- Ensure cleanup actions in `durable` always happen when the wrapped code raises an unexpected error.
### Removed
- `_contextmanager_without_decorator`, `_NonDecoratorContextManager`, `NotADecorator`.
  These implementation details were not intended to be a part of our public API.