### PR TITLE
Tag docs builds by released versions

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -84,5 +84,5 @@ jobs:
           git config --global user.email "django-subatomic+docs@example.com"
       - name: Build Docs Site
         run: |
-          mike deploy --push --update-aliases ${{ github.event.release.tag_name }} latest
+          mike deploy --push --update-aliases ${{ github.ref_name }} latest
           mike set-default latest --push


### PR DESCRIPTION
When doing releases, we intended to tag each version for posterity, but have not been doing so. This is because we build on git tag events, but were trying to use the tag name from GitHub Release event data which was not available while handling the tag event.

By switching to `github.ref_name` instead, we should store each version's docs for later reference (and perma-linking).

See: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context

Fixes https://github.com/kraken-tech/django-subatomic/issues/121