### PR TITLE
Run tests against DBs other than Postgres

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,19 @@ jobs:
     timeout-minutes: 5
 
     services:
+      mariadb:
+        image: mariadb
+        env:
+          MARIADB_ROOT_PASSWORD: rootpassword
+          MARIADB_DATABASE: subatomic
+        options: >-
+          --health-cmd "mariadb-check --all-databases -h 127.0.0.1 -u root -p'rootpassword'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3306:3306
+
       postgres:
         image: postgres
         env:
@@ -48,6 +61,8 @@ jobs:
         FORCE_COLOR: "1"
         DEFAULT_POSTGRES_URL: postgres://postgres:postgres@localhost/subatomic
         OTHER_POSTGRES_URL: postgres://postgres:postgres@localhost/subatomic_other
+        DEFAULT_MARIADB_URL: mysql://root:rootpassword@127.0.0.1:3306/subatomic
+        OTHER_MARIADB_URL: mysql://root:rootpassword@127.0.0.1:3306/subatomic_other
 
   docs:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,8 @@ jobs:
     - run: tox run-parallel --parallel-no-spinner
       env:
         FORCE_COLOR: "1"
-        DEFAULT_DATABASE_URL: postgres://postgres:postgres@localhost/subatomic
-        OTHER_DATABASE_URL: postgres://postgres:postgres@localhost/subatomic_other
+        DEFAULT_POSTGRES_URL: postgres://postgres:postgres@localhost/subatomic
+        OTHER_POSTGRES_URL: postgres://postgres:postgres@localhost/subatomic_other
 
   docs:
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Added MariaDB and SQLite to the test matrix.
+
 ## [1.0.0] - 2026-04-16
 
 ## [0.2.1] - 2026-02-06

--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ This package supports sensible combinations of:
 
 - Python 3.12, 3.13, 3.14.
 - Django 4.2, 5.1, 5.2, 6.0.
+- SQLite, PostgreSQL, MariaDB.
 
 [atomic]: https://docs.djangoproject.com/en/stable/topics/db/transactions/#django.db.transaction.atomic

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -782,6 +782,18 @@ class TestInTransaction:
         with transaction_manager(using=DEFAULT):
             assert db.in_transaction(using=DEFAULT) is True
 
+    @pytest.mark.skipif(
+        # If database is in memory, closing the connection destroys the
+        # database. To prevent accidental data loss, Django ignores close
+        # requests on an in-memory db. Given the database is in-memory,
+        # there's no cost to maintaining an open connection, so we don't
+        # need to test that we don't open a connection here.
+        all(
+            django_db.connections[db_alias].vendor == "sqlite"
+            for db_alias in django_db.connections
+        ),
+        reason="Doesn't apply to SQLite",
+    )
     @pytest.mark.django_db(databases=[])
     def test_database_connection_not_opened(self) -> None:
         """
@@ -828,6 +840,18 @@ class TestDBsWithOpenTransaction:
 
         assert dbs == frozenset({DEFAULT, OTHER})
 
+    @pytest.mark.skipif(
+        # If database is in memory, closing the connection destroys the
+        # database. To prevent accidental data loss, Django ignores close
+        # requests on an in-memory db. Given the database is in-memory,
+        # there's no cost to maintaining an open connection, so we don't
+        # need to test that we don't open a connection here.
+        all(
+            django_db.connections[db_alias].vendor == "sqlite"
+            for db_alias in django_db.connections
+        ),
+        reason="Doesn't apply to SQLite",
+    )
     @pytest.mark.django_db(databases=[])
     def test_database_connection_not_opened(self) -> None:
         """

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4
 
 env_list =
-    py3{12,13,14}-django{42,51,52,60}-postgres
+    py3{12,13,14}-django{42,51,52,60}-{mariadb,postgres}
     coverage
     mypy
 
@@ -15,6 +15,8 @@ package = wheel
 wheel_build_env = .pkg
 
 setenv =
+    mariadb: DEFAULT_DATABASE_URL={env:DEFAULT_MARIADB_URL:mysql:///subatomic/}
+    mariadb: OTHER_DATABASE_URL={env:OTHER_MARIADB_URL:mysql:///subatomic_other/}
     postgres: DEFAULT_DATABASE_URL={env:DEFAULT_POSTGRES_URL:postgres:///subatomic}
     postgres: OTHER_DATABASE_URL={env:OTHER_POSTGRES_URL:postgres:///subatomic_other}
 
@@ -27,6 +29,7 @@ deps =
     django51: django~=5.1.0
     django52: django~=5.2.0
     django60: django~=6.0.0
+    mariadb: mysqlclient
 
 commands =
     coverage run --parallel -m pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4
 
 env_list =
-    py3{12,13,14}-django{42,51,52,60}
+    py3{12,13,14}-django{42,51,52,60}-postgres
     coverage
     mypy
 
@@ -14,9 +14,9 @@ package = wheel
 # Share the build environment between tox environments.
 wheel_build_env = .pkg
 
-pass_env =
-    DEFAULT_DATABASE_URL
-    OTHER_DATABASE_URL
+setenv =
+    postgres: DEFAULT_DATABASE_URL={env:DEFAULT_POSTGRES_URL:postgres:///subatomic}
+    postgres: OTHER_DATABASE_URL={env:OTHER_POSTGRES_URL:postgres:///subatomic_other}
 
 dependency_groups =
     coverage
@@ -33,7 +33,7 @@ commands =
 
 [testenv:coverage]
 depends =
-    py3{12,13,14}-django{42,51,52,60}
+    py3{12,13,14}-django{42,51,52,60}-postgres
 
 dependency_groups =
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4
 
 env_list =
-    py3{12,13,14}-django{42,51,52,60}-{mariadb,postgres}
+    py3{12,13,14}-django{42,51,52,60}-{mariadb,postgres,sqlite}
     coverage
     mypy
 
@@ -19,6 +19,8 @@ setenv =
     mariadb: OTHER_DATABASE_URL={env:OTHER_MARIADB_URL:mysql:///subatomic_other/}
     postgres: DEFAULT_DATABASE_URL={env:DEFAULT_POSTGRES_URL:postgres:///subatomic}
     postgres: OTHER_DATABASE_URL={env:OTHER_POSTGRES_URL:postgres:///subatomic_other}
+    sqlite: DEFAULT_DATABASE_URL={env:DEFAULT_SQLITE_URL:sqlite:///test-default-db.sqlite}
+    sqlite: OTHER_DATABASE_URL={env:OTHER_SQLITE_URL:sqlite:///test-other-db.sqlite}
 
 dependency_groups =
     coverage


### PR DESCRIPTION
We were previously only running the test suite against Postgres. This adds MariaDB and SQLite to the test suite and CI.

Fixes #91.