### PR TITLE
Remove changelog entry added to the wrong project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
-
-- The `--since` CLI option
-  allows a base reference to be provided.
-  This facilitates checking commits since a default branch
-  that is not called 'main'.
-
 ## [1.0.0] - 2026-04-16
 
 ## [0.2.1] - 2026-02-06


### PR DESCRIPTION
This was added to this project's changelog by mistake.

---

One peril of using a standard changelog format is that I fail to notice that I'm in the wrong project 🤦🏻 