### PR TITLE
Remove unnecessary tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ env_list =
     py3{12,13,14}-django{42,51,52,60}
     coverage
     mypy
-    validate_commits
 
 [testenv]
 # Install wheels instead of source distributions for faster execution.


### PR DESCRIPTION
This was added by mistake in 6c5c227b1bde967e4e2d2aa1e7ed4e3b67baf7fa.
This environment has no specific configuration, so runs the tests, like
the py* environments, but without specifying the version of Django or
Python.
