### PR TITLE
fix: disallow nesting `part_of_a_transaction`

### DIFF
--- a/src/django_subatomic/test.py
+++ b/src/django_subatomic/test.py
@@ -32,5 +32,5 @@ def part_of_a_transaction(using: str | None = None) -> Generator[None]:
     Note that this does not handle after-commit callback simulation. If you need that,
     use [`transaction`][django_subatomic.db.transaction] instead.
     """
-    with transaction.atomic(using=using):
+    with transaction.atomic(using=using, durable=True):
         yield


### PR DESCRIPTION
## What changed

Pass `durable=True` to `transaction.atomic()` inside `part_of_a_transaction` to prevent nesting.

## Why

Just as it doesn't make sense for transactions to be nested, it doesn't make sense for tests to simulate nesting of parts of transactions. Using `durable=True` ensures that `part_of_a_transaction` cannot be nested inside another `part_of_a_transaction`, which would be semantically incorrect.

## How it was tested

- Ran the full test suite with SQLite: `83 passed, 2 skipped`
- Verified the change is minimal and surgical: only adding `durable=True` parameter

Fixes #150