### PR TITLE
fix: disallow nesting of part_of_a_transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Added MariaDB and SQLite to the test matrix.
+- Disallowed nesting of `part_of_a_transaction` to prevent accidental
+  simulation of nested transaction behaviour in tests. Fixes #150.
 
 ## [1.0.0] - 2026-04-16
 

--- a/src/django_subatomic/test.py
+++ b/src/django_subatomic/test.py
@@ -32,5 +32,5 @@ def part_of_a_transaction(using: str | None = None) -> Generator[None]:
     Note that this does not handle after-commit callback simulation. If you need that,
     use [`transaction`][django_subatomic.db.transaction] instead.
     """
-    with transaction.atomic(using=using):
+    with transaction.atomic(using=using, durable=True):
         yield

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -413,6 +413,50 @@ class TestSavepointContextManager:
         assert release_savepoint["sql"].startswith("RELEASE SAVEPOINT ")
 
 
+class TestPartOfATransaction:
+    @pytest.mark.django_db(transaction=True)
+    def test_fails_when_nested_inside_another_part_of_a_transaction(self) -> None:
+        """
+        `part_of_a_transaction` cannot be nested inside another `part_of_a_transaction`.
+        """
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape(
+                "A durable atomic block cannot be nested within another atomic block."
+            ),
+        ):
+            with test.part_of_a_transaction():
+                with test.part_of_a_transaction():
+                    ...
+
+    @pytest.mark.django_db(transaction=True)
+    def test_fails_when_nested_inside_an_atomic_block(self) -> None:
+        """
+        `part_of_a_transaction` cannot be nested inside an existing atomic block.
+        """
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape(
+                "A durable atomic block cannot be nested within another atomic block."
+            ),
+        ):
+            with django_transaction.atomic():
+                with test.part_of_a_transaction():
+                    ...
+
+    @pytest.mark.django_db(transaction=True)
+    def test_creates_transaction(self) -> None:
+        """
+        A transaction is active within the context manager.
+        """
+        assert django_transaction.get_autocommit() is True
+
+        with test.part_of_a_transaction():
+            assert django_transaction.get_autocommit() is False
+
+        assert django_transaction.get_autocommit() is True
+
+
 class TestTransactionIfNotAlready:
     def test_transaction_already_exists(
         self, django_assert_num_queries: pytest_django.DjangoAssertNumQueries


### PR DESCRIPTION
## What changed

Add  to the `atomic` call inside `part_of_a_transaction` so that nesting is explicitly disallowed.

## Why

As noted in #150, just as it doesn't make sense for transactions to be nested, it doesn't make sense for tests to simulate nesting of parts of transactions. Adding `durable=True` causes Django to raise a `RuntimeError` if `part_of_a_transaction` is called inside an existing atomic block, preventing accidental misuse.

## Changes

1. **src/django_subatomic/test.py**: Add `durable=True` to `transaction.atomic()` call
2. **tests/test_db.py**: Add `TestPartOfATransaction` class with 3 tests:
   - Nesting `part_of_a_transaction` inside another raises `RuntimeError`
   - Nesting `part_of_a_transaction` inside an existing `atomic` block raises `RuntimeError`
   - `part_of_a_transaction` correctly creates a transaction when used standalone
3. **CHANGELOG.md**: Document the change in the Unreleased section

## How to test

```sh
python -m pytest tests/test_db.py::TestPartOfATransaction -v
```

All 3 new tests pass, and the full test suite (86 passed, 2 skipped) is green.

Fixes #150