### PR TITLE
Disallow nesting `part_of_a_transaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Added MariaDB and SQLite to the test matrix.
+- Disallowed nesting of `part_of_a_transaction` to prevent nonsense
+  implication of nested partial transactions in tests. Fixes #150.
 
 ## [1.0.0] - 2026-04-16
 

--- a/src/django_subatomic/test.py
+++ b/src/django_subatomic/test.py
@@ -32,5 +32,5 @@ def part_of_a_transaction(using: str | None = None) -> Generator[None]:
     Note that this does not handle after-commit callback simulation. If you need that,
     use [`transaction`][django_subatomic.db.transaction] instead.
     """
-    with transaction.atomic(using=using):
+    with transaction.atomic(using=using, durable=True):
         yield

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,8 +1,22 @@
 from __future__ import annotations
 
+import re
+from typing import TYPE_CHECKING
+
 import pytest
+from django.db import transaction as django_transaction
 
 from django_subatomic import db, test
+
+
+if TYPE_CHECKING:
+    import contextlib
+    from typing import Protocol
+
+    class DBContextManager(Protocol):
+        def __call__(
+            self, *, using: str | None = None
+        ) -> contextlib.AbstractContextManager[None, None]: ...
 
 
 DEFAULT = "default"
@@ -35,3 +49,28 @@ class TestPartOfATransaction:
 
         with test.part_of_a_transaction():
             db.run_after_commit(_callback_which_should_not_be_called)
+
+    @pytest.mark.parametrize(
+        "transaction_manager",
+        (
+            db.transaction,
+            db.transaction_if_not_already,
+            django_transaction.atomic,
+            test.part_of_a_transaction,
+        ),
+    )
+    def test_fails_when_nested_inside_an_atomic_block(
+        self, transaction_manager: DBContextManager
+    ) -> None:
+        """
+        `part_of_a_transaction` cannot be nested inside another atomic block.
+        """
+        with transaction_manager():
+            with pytest.raises(
+                RuntimeError,
+                match=re.escape(
+                    "A durable atomic block cannot be nested within another atomic block."
+                ),
+            ):
+                with test.part_of_a_transaction():
+                    ...

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from django_subatomic import db, test
+
+
+DEFAULT = "default"
+pytestmark = [pytest.mark.django_db(databases=[DEFAULT])]
+
+
+class TestPartOfATransaction:
+    """
+    Tests of `part_of_a_transaction`.
+    """
+
+    def test_simulates_transaction(self) -> None:
+        """
+        A transaction appears to be open inside `part_of_a_transaction`.
+        """
+        assert db.in_transaction() is False
+
+        with test.part_of_a_transaction():
+            assert db.in_transaction() is True
+
+        assert db.in_transaction() is False
+
+    def test_callbacks_not_executed_in_normal_test_case(self) -> None:
+        """
+        Callbacks aren't executed when tests manage the transaction.
+        """
+
+        def _callback_which_should_not_be_called() -> None:
+            pytest.fail("Callback should not have been called.")  # pragma: no cover
+
+        with test.part_of_a_transaction():
+            db.run_after_commit(_callback_which_should_not_be_called)


### PR DESCRIPTION
Just as it doesn't make sense for transactions to be nested, it doesn't make sense for tests to simulate nesting of parts of transactions.

This fixes #150 and is a rework of #152. In acknowledgement on the reworked commits, I have listed the commits as co-authored with @Giggitycountless.