### PR TITLE
Simplify error behaviour of `transaction_if_not_already`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Exceptions raised through `transaction_if_not_already`
+  when it was called from inside an existing transaction
+  will no longer invalidate the outer transaction's context.
+
 ### Added
 - Added MariaDB and SQLite to the test matrix.
 - `part_of_a_transaction` now raises an error if unhandled callbacks are detected when it starts.

--- a/src/django_subatomic/db.py
+++ b/src/django_subatomic/db.py
@@ -57,10 +57,10 @@ def transaction[**P, R](
 
     @contextlib.contextmanager
     def _transaction(*, using: str | None) -> Generator[None]:
-        # Note that `savepoint=False` is not required here because
-        # the `savepoint` flag is ignored when `durable` is `True`.
         with (
             _execute_on_commit_callbacks_in_tests(using),
+            # Note that `savepoint=False` is not required on `atomic` because
+            # the `savepoint` flag is ignored when `durable` is `True`.
             django_transaction.atomic(using=using, durable=True),
         ):
             yield
@@ -115,13 +115,13 @@ def transaction_if_not_already[**P, R](
 
     @contextlib.contextmanager
     def _transaction_if_not_already(*, using: str | None = None) -> Generator[None]:
-        # If the innermost atomic block is from a test case, we should create a SAVEPOINT here.
-        # This allows for a rollback when an exception propagates out of this block, and so
-        # better simulates a production transaction behaviour in tests.
         savepoint = _innermost_atomic_block_wraps_testcase(using=using)
 
         with (
             _execute_on_commit_callbacks_in_tests(using),
+            # If the innermost atomic block is from a test case, we should create a SAVEPOINT here.
+            # This allows for a rollback when an exception propagates out of this block, and so
+            # better simulates a production transaction behaviour in tests.
             django_transaction.atomic(using=using, savepoint=savepoint),
         ):
             yield

--- a/src/django_subatomic/db.py
+++ b/src/django_subatomic/db.py
@@ -99,11 +99,6 @@ def transaction_if_not_already[**P, R](
         which use it may need further work to achieve full control over how
         transactions are managed.
 
-    Warning:
-        If this function is called when a transaction is already open, errors raised
-        through it will invalidate the current transaction, regardless of where
-        it was opened.
-
     Tip: Suggested alternatives
         - In functions which should not control transactions,
           use [`transaction_required`][django_subatomic.db.transaction_required].
@@ -122,7 +117,8 @@ def transaction_if_not_already[**P, R](
             # better simulates a production transaction behaviour in tests.
             atomic_context = transaction(using=using)
         else:
-            atomic_context = django_transaction.atomic(using=using, savepoint=False)
+            # If we're already in a transaction, do nothing.
+            atomic_context = contextlib.nullcontext()
 
         with atomic_context:
             yield

--- a/src/django_subatomic/db.py
+++ b/src/django_subatomic/db.py
@@ -110,17 +110,14 @@ def transaction_if_not_already[**P, R](
 
     @contextlib.contextmanager
     def _transaction_if_not_already(*, using: str | None = None) -> Generator[None]:
-        atomic_context: contextlib.AbstractContextManager[None]
-        if not in_transaction(using=using):
-            # If the innermost atomic block is from a test case, `transaction` will create a SAVEPOINT.
-            # This allows for a rollback when an exception propagates out of this block, and so
-            # better simulates a production transaction behaviour in tests.
-            atomic_context = transaction(using=using)
-        else:
-            # If we're already in a transaction, do nothing.
-            atomic_context = contextlib.nullcontext()
+        if in_transaction(using=using):
+            yield  # If we're already in a transaction, do nothing.
+            return
 
-        with atomic_context:
+        # If the innermost atomic block is from a test case, `transaction` will create a SAVEPOINT.
+        # This allows for a rollback when an exception propagates out of this block, and so
+        # better simulates a production transaction behaviour in tests.
+        with transaction(using=using):
             yield
 
     decorator = _transaction_if_not_already(using=using)

--- a/src/django_subatomic/db.py
+++ b/src/django_subatomic/db.py
@@ -115,15 +115,16 @@ def transaction_if_not_already[**P, R](
 
     @contextlib.contextmanager
     def _transaction_if_not_already(*, using: str | None = None) -> Generator[None]:
-        savepoint = _innermost_atomic_block_wraps_testcase(using=using)
-
-        with (
-            _execute_on_commit_callbacks_in_tests(using),
-            # If the innermost atomic block is from a test case, we should create a SAVEPOINT here.
+        atomic_context: contextlib.AbstractContextManager[None]
+        if not in_transaction(using=using):
+            # If the innermost atomic block is from a test case, `transaction` will create a SAVEPOINT.
             # This allows for a rollback when an exception propagates out of this block, and so
             # better simulates a production transaction behaviour in tests.
-            django_transaction.atomic(using=using, savepoint=savepoint),
-        ):
+            atomic_context = transaction(using=using)
+        else:
+            atomic_context = django_transaction.atomic(using=using, savepoint=False)
+
+        with atomic_context:
             yield
 
     decorator = _transaction_if_not_already(using=using)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -435,23 +435,6 @@ class TestTransactionIfNotAlready:
 
         assert django_transaction.get_autocommit() is True
 
-    def test_cannot_query_after_exception_in_test_case(self) -> None:
-        """
-        Check that we do not have a working database connection and may not do queries after
-        catching an exception and before rolling back.
-
-        The outer atomic block will be unusable because we have not rolled back after the
-        exception.
-        """
-        with db.transaction():
-            with pytest.raises(_AnError):
-                with db.transaction_if_not_already():
-                    raise _AnError
-
-            with pytest.raises(django_transaction.TransactionManagementError):
-                with django_db.connections["default"].cursor() as cursor:
-                    cursor.execute("SELECT 1")
-
     def test_can_query_after_exception_in_test_case(self) -> None:
         """
         Check that we have a working database connection and may do queries after catching an exception.


### PR DESCRIPTION
Before this change, errors raised through `transaction_if_not_already` would invalidate the state of any outer transaction (other than a test's transaction).

That was a side-effect of the fact that we used `atomic(savepoint=False)` in that case.

This avoids that pitfall by using `contextlib.nullcontext` when a transaction is already open. The logic of `transaction_if_not_already` becomes easier to understand as a result.

~Because this changes production behaviour, this change will require a 2.0 release.~
Edit: As per review comments, we will not make a 2.0 release as a result of this change.