### PR TITLE
Remove `attrs` dependency to improve import times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Exceptions raised through `transaction_if_not_already`
   when it was called from inside an existing transaction
   will no longer invalidate the outer transaction's context.
+- Remove `attrs` dependency.
 
 ### Added
 - Added MariaDB and SQLite to the test matrix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 
 requires-python = ">=3.12"
 dependencies = [
-    "attrs",
     "django",
 ]
 

--- a/src/django_subatomic/db.py
+++ b/src/django_subatomic/db.py
@@ -4,7 +4,6 @@ import contextlib
 import functools
 from typing import TYPE_CHECKING, overload
 
-import attrs
 from django import db as django_db
 from django.conf import settings
 from django.db import transaction as django_transaction
@@ -302,7 +301,6 @@ def _execute_on_commit_callbacks_in_tests(using: str | None = None) -> Generator
 # we need to permit the test-suite's transaction.
 
 
-@attrs.frozen
 class _MissingRequiredTransaction(Exception):
     """
     Raised by `transaction_required` when we're not in a transaction.
@@ -325,10 +323,11 @@ class _MissingRequiredTransaction(Exception):
     This exception should not be caught, as it indicates a programming error.
     """
 
-    database: str
+    def __init__(self, database: str) -> None:
+        super().__init__()
+        self.database = database
 
 
-@attrs.frozen
 class _AmbiguousAfterCommitTestBehaviour(Exception):
     """
     Raised in tests when it's unclear if after-commit callbacks should be run.
@@ -356,10 +355,11 @@ class _AmbiguousAfterCommitTestBehaviour(Exception):
     This exception should not be caught, as it indicates a programming error.
     """
 
-    database: str
+    def __init__(self, database: str) -> None:
+        super().__init__()
+        self.database = database
 
 
-@attrs.frozen
 class _UnexpectedOpenTransaction(Exception):
     """
     Raised when calling a `durable` function with an open transaction.
@@ -374,10 +374,11 @@ class _UnexpectedOpenTransaction(Exception):
     This exception should not be caught, as it indicates a programming error.
     """
 
-    open_dbs: frozenset[str]
+    def __init__(self, open_dbs: frozenset[str]) -> None:
+        super().__init__()
+        self.open_dbs = open_dbs
 
 
-@attrs.frozen
 class _UnexpectedDanglingTransaction(Exception):
     """
     Raised when a `durable` function exits with a transaction open.
@@ -388,10 +389,11 @@ class _UnexpectedDanglingTransaction(Exception):
     This exception should not be caught, as it indicates a programming error.
     """
 
-    open_dbs: frozenset[str]
+    def __init__(self, open_dbs: frozenset[str]) -> None:
+        super().__init__()
+        self.open_dbs = open_dbs
 
 
-@attrs.frozen
 class _UnhandledCallbacks(Exception):
     """
     Raised in tests when unhandled callbacks are found before opening a transaction.
@@ -402,7 +404,9 @@ class _UnhandledCallbacks(Exception):
     The best solution is to ensure the after-commit callbacks are run.
     """
 
-    callbacks: tuple[Callable[[], object], ...]
+    def __init__(self, callbacks: tuple[Callable[[], object], ...]) -> None:
+        super().__init__()
+        self.callbacks = callbacks
 
 
 # Note [After-commit callbacks require a transaction]

--- a/src/django_subatomic/test.py
+++ b/src/django_subatomic/test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING
 
-import attrs
 from django.conf import settings
 from django.db import transaction
 
@@ -16,7 +15,6 @@ __all__ = [
 ]
 
 
-@attrs.frozen
 class _UnhandledCallbacks(Exception):
     """
     Raised in tests when unhandled callbacks are found before calling `part_of_a_transaction`.
@@ -27,7 +25,9 @@ class _UnhandledCallbacks(Exception):
     The best solution is to ensure the after-commit callbacks are handled first.
     """
 
-    callbacks: tuple[Callable[[], object], ...]
+    def __init__(self, callbacks: tuple[Callable[[], object], ...]) -> None:
+        super().__init__()
+        self.callbacks = callbacks
 
 
 class _OnlyForUseInDjangoTestTransaction(Exception):


### PR DESCRIPTION
This shaves around 10ms (~18%) off the import time.

It removes the immutability of the exceptions, but as the exceptions are intended for dev and not to be handled, this trade-off is worthwhile.

I've left the attribute types in place, on the off chance they're useful. It does duplicate the types for potentially little/no gain so also happy to remove.