### PR TITLE
Correctly check out the repository so `validate-commits` works for forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,11 +86,16 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.repository }}
           fetch-depth: 0
-    - run: |
-        git fetch origin main
-        git branch main origin/main
+    - name: Check out fork
+      run: |
+        git remote add fork "$FORK_REPO"
+        git fetch fork "$HEAD_REF"
+        git checkout "$HEAD_REF"
+      env:
+        FORK_REPO: https://github.com/${{ github.event.pull_request.head.repo.full_name }}
+        HEAD_REF: ${{ github.head_ref }}
     - uses: actions/setup-python@v6
       with:
         python-version-file: '.github/workflows/.python-version'


### PR DESCRIPTION
The previous checkout mechanism only worked for branches on the source repository, not for forks.

This change checks out the source repository, and adds the fork as another remote which is then checked out. This keeps `main` as the upstream, and keeps the fork branch.

This may do strange things if the branch isn't up-to-date with `main`, but there may not be a simple way around that (outside of `validate-commits` itself).