### PR TITLE
Validate commits fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,11 +88,8 @@ jobs:
       with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-    - run: |
-        git fetch origin main
-        git branch main origin/main
     - uses: actions/setup-python@v6
       with:
         python-version-file: '.github/workflows/.python-version'
     - run: pip install validate_commits
-    - run: validate-commits
+    - run: validate-commits --since=origin/main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
     - run: |
         git fetch origin main


### PR DESCRIPTION
Before this change, it wasn't possible to run the `validate-commits` job on PRs opened from forks. This change should fix the errors we saw ([e.g.](https://github.com/kraken-tech/django-subatomic/actions/runs/26174519084/job/77002522724?pr=161)).