### PR TITLE
Test against Django 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Django 6.1 has been added to the test matrix.
+
 ### Changed
 
 - Exceptions raised through `transaction_if_not_already`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Documentation can be found at <https://kraken-tech.github.io/django-subatomic/>.
 This package supports sensible combinations of:
 
 - Python 3.12, 3.13, 3.14.
-- Django 4.2, 5.1, 5.2, 6.0.
+- Django 4.2, 5.1, 5.2, 6.0, 6.1.
 - SQLite, PostgreSQL, MariaDB.
 
 [atomic]: https://docs.djangoproject.com/en/stable/topics/db/transactions/#django.db.transaction.atomic

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4
 
 env_list =
-    py3{12,13,14}-django{42,51,52,60}-{mariadb,postgres,sqlite}
+    py3{12,13,14}-django{42,51,52,60,61}-{mariadb,postgres,sqlite}
     coverage
     mypy
 
@@ -31,6 +31,7 @@ deps =
     django51: django~=5.1.0
     django52: django~=5.2.0
     django60: django~=6.0.0
+    django61: django~=6.1.0
     mariadb: mysqlclient
 
 commands =
@@ -38,7 +39,7 @@ commands =
 
 [testenv:coverage]
 depends =
-    py3{12,13,14}-django{42,51,52,60}-postgres
+    py3{12,13,14}-django{42,51,52,60,61}-postgres
 
 dependency_groups =
     coverage


### PR DESCRIPTION
This change adds Django 6.1 to the test matrix.